### PR TITLE
feat: use uv.fs_rename instead of mv

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ I've covered the current functions with LSP integration tests using
   [Watchman](https://facebook.github.io/watchman/), but way beyond my current
   Lua abilities.
 
-- [ ] ~~Make sure everything works on Linux (it should)~~ and on Windows (it
-      shouldn't).
+- [x] ~~Make sure everything works on Linux (it should) and on Windows (it
+      shouldn't).~~
 
-  I have no idea what `os.execute` will do on Windows, but `LspRenameFile` uses
-  `mv`, which (as far as I know) won't work.
+  ~~I have no idea what `os.execute` will do on Windows, but `LspRenameFile` uses
+  `mv`, which (as far as I know) won't work.~~

--- a/lua/nvim-lsp-ts-utils/utils.lua
+++ b/lua/nvim-lsp-ts-utils/utils.lua
@@ -11,7 +11,7 @@ end
 M.list_contains = list_contains
 
 M.move_file = function(path1, path2)
-    local ok = os.execute("mv '" .. path1 .. "' '" .. path2 .. "'")
+    local ok = vim.loop.fs_rename(path1, path2)
 
     if not ok then
         return false, "failed to move " .. path1 .. " to " .. path2


### PR DESCRIPTION
This *should* provide Windows support. I couldn't run the test because `lspconfig` didn't found and I couldn't make it work, but I've tested it manually and it works, so hopefully it works consistently :)