### PR TITLE
make 'optimize imports' sync

### DIFF
--- a/lua/nvim-lsp-ts-utils.lua
+++ b/lua/nvim-lsp-ts-utils.lua
@@ -9,7 +9,7 @@ local organize_imports = function()
         command = "_typescript.organizeImports",
         arguments = {vim.api.nvim_buf_get_name(0)}
     }
-    vim.lsp.buf.execute_command(params)
+    lsp.buf_request_sync(0, "workspace/executeCommand", params)
 end
 M.organize_imports = organize_imports
 


### PR DESCRIPTION
hey! thanks for pr!
The purpose of that plugin is to make 'optimize imports' behave concise with all other commands ( to be sync by default )
I've tested this using example functions:
```
function _oi()
    local params = {
        command = "_typescript.organizeImports",
        arguments = {vim.api.nvim_buf_get_name(0)}
    }
    local responses = lsp.buf_request_sync(0, "workspace/executeCommand", params)
    vim.cmd(":noautocmd write")
end

function _oi2()
    require "nvim-lsp-ts-utils".organize_imports()
    vim.cmd(":noautocmd write")
end

function _oi3()
    vim.cmd(":LspOrganize")
    vim.cmd(":noautocmd write")
end
```
after `_oi` buffer is not in 'modified' state, when after `_oi2`, `_oi3` it is, which makes me think that `executeCommand` you do is async...