### PR TITLE
fix: set code to ruleId, similar to other lsp servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ something doesn't work, please let me know!
 
   Supports the following settings:
 
-  - `eslint_binary`: sets the binary used to get ESLint output.
+  - `eslint_bin`: sets the binary used to get ESLint output.
 
     Uses `eslint` by
     default for compatibility, but I highly, highly recommend using
@@ -98,7 +98,7 @@ something doesn't work, please let me know!
     change. This variable modifies the amount of time between diagnostic
     refreshes. Set to `250` (ms) by default.
 
-  - `eslint_binary` and `eslint_args`: applies the same settings as ESLint code
+  - `eslint_bin` and `eslint_args`: applies the same settings as ESLint code
     actions.
 
 - Formatting via [Prettier](https://github.com/prettier/prettier)

--- a/lua/nvim-lsp-ts-utils/request-handlers.lua
+++ b/lua/nvim-lsp-ts-utils/request-handlers.lua
@@ -231,8 +231,8 @@ end
 
 local create_diagnostic = function(message)
     return {
-        message = message.ruleId and message.message .. " [" .. message.ruleId ..
-            "]" or message.message,
+        message = message.ruleId and message.message,
+        code = message.ruleId,
         range = get_diagnostic_range(message),
         severity = message.severity,
         source = "eslint"


### PR DESCRIPTION
`ruleid` should be in the `code` field, instead of part of the message (fixes #10)

This now correctly displays in Trouble:
![image](https://user-images.githubusercontent.com/292349/115863896-fa2f2300-a3ea-11eb-801c-e84beb5615ff.png)
