### PR TITLE
fix: eslint severity is opposite of lsp severity

### DIFF
--- a/lua/nvim-lsp-ts-utils/request-handlers.lua
+++ b/lua/nvim-lsp-ts-utils/request-handlers.lua
@@ -230,11 +230,15 @@ M.buf_request = function(bufnr, method, params, handler)
 end
 
 local create_diagnostic = function(message)
+    -- eslint severity can be:
+    -- 1: warning
+    -- 2: error
+    -- lsp severity is the opposite
     return {
-        message = message.ruleId and message.message,
+        message = message.message,
         code = message.ruleId,
         range = get_diagnostic_range(message),
-        severity = message.severity,
+        severity = message.severity == 1 and 2 or 1,
         source = "eslint"
     }
 end


### PR DESCRIPTION
Severity levels from eslint can be 1 for warning and 2 for error.

Lsp levels are the other way around.

This PR fixes this.