### PR TITLE
Add referenced client in eslint setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ An example showing the available settings and their defaults:
 local nvim_lsp = require("lspconfig")
 
 nvim_lsp.tsserver.setup {
-    on_attach = function(_, bufnr)
+    on_attach = function(client, bufnr)
         local ts_utils = require("nvim-lsp-ts-utils")
 
         -- defaults


### PR DESCRIPTION
Since `client` is referenced in `ts_utills.setup_client(client)` it shouldn't be `_` in the params