### PR TITLE
Add React Typescript filetypes to null-ls integration

### DIFF
--- a/lua/nvim-lsp-ts-utils/utils.lua
+++ b/lua/nvim-lsp-ts-utils/utils.lua
@@ -40,6 +40,8 @@ M.tsserver_fts = {
     "javascriptreact",
     "typescript",
     "typescriptreact",
+    "javascript.jsx",
+    "typescript.tsx",
 }
 
 M.tsserver_extension_pattern = "[.][tj][s]x?$"


### PR DESCRIPTION
JSX/TSX files are mapped to one of the two filetypes - either with "react" prefix or ".jsx"/".tsx" prefix. This makes sure all of the permutations are covered