### PR TITLE
[WIP] feat(import all): implement priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,15 @@ possibility. If something doesn't work, please let me know!
   below).
 
   By default, the command will resolve conflicting imports by checking other
-  imports in the same file and other open buffers. This has a minor performance
-  impact, but you can disable the feature entirely by setting
+  imports in the same file and other open buffers. In Git repositories, it will
+  check project files to improve accuracy. This feature has a small performance
+  impact, but you can disable it entirely by setting
   `import_all_disable_priority` to `true` (see below).
 
-  `:TSLspImportAll` can also scan the content of other open buffers to resolve
-  import priority, limited by `import_all_scan_buffers` (set to `0` by default).
-  This has a positive impact on import accuracy but a larger performance impact.
+  `:TSLspImportAll` will also scan the content of other open buffers to resolve
+  import priority, limited by `import_all_scan_buffers`. This has a positive
+  impact on import accuracy but may hurt performance when run with a large
+  number (100+) of loaded buffers.
 
 - Import on completion
 
@@ -267,7 +269,7 @@ nvim_lsp.tsserver.setup {
             -- import all
             import_all_timeout = 5000, -- ms
             import_all_disable_priority = false,
-            import_all_scan_buffers = 0
+            import_all_scan_buffers = 100,
 
             -- eslint
             eslint_enable_code_actions = true,

--- a/README.md
+++ b/README.md
@@ -46,22 +46,21 @@ possibility. If something doesn't work, please let me know!
   (imperfectly) determine whether it's an import action. Also organizes imports
   afterwards to merge imports from the same source.
 
-  Note that `tsserver` has a tendency to time out when making large requests. If
-  you frequently see timeout warnings, you can change `import_all_timeout` (see
-  below).
-
   By default, the command will resolve conflicting imports by checking other
   imports in the same file and other open buffers. In Git repositories, it will
   check project files to improve accuracy. You can alter the weight given to
-  each factor by modifying `import_all_priorities` (see below).
-
-  This feature has a minimal performance impact, but you can disable it entirely
-  by setting `import_all_priorities` to `nil`.
+  each factor by modifying `import_all_priorities` (see below). This feature
+  has a minimal performance impact, but you can disable it entirely by setting
+  `import_all_priorities` to `nil`.
 
   `:TSLspImportAll` will also scan the content of other open buffers to resolve
   import priority, limited by `import_all_scan_buffers`. This has a positive
   impact on import accuracy but may affect performance when run with a large
   number (100+) of loaded buffers.
+
+  Instead of priority, you could also set `import_all_select_source` to `true`,
+  which will prompt you to choose from the available options when there's a
+  conflict.
 
 - Import on completion
 
@@ -277,6 +276,7 @@ nvim_lsp.tsserver.setup {
                 same_file = 1, -- add to existing import statement
             },
             import_all_scan_buffers = 100,
+            import_all_select_source = false,
 
             -- eslint
             eslint_enable_code_actions = true,

--- a/README.md
+++ b/README.md
@@ -52,13 +52,15 @@ possibility. If something doesn't work, please let me know!
 
   By default, the command will resolve conflicting imports by checking other
   imports in the same file and other open buffers. In Git repositories, it will
-  check project files to improve accuracy. This feature has a small performance
-  impact, but you can disable it entirely by setting
-  `import_all_disable_priority` to `true` (see below).
+  check project files to improve accuracy. You can alter the weight given to
+  each factor by modifying `import_all_priorities` (see below).
+
+  This feature has a minimal performance impact, but you can disable it entirely
+  by setting `import_all_priorities` to `nil`.
 
   `:TSLspImportAll` will also scan the content of other open buffers to resolve
   import priority, limited by `import_all_scan_buffers`. This has a positive
-  impact on import accuracy but may hurt performance when run with a large
+  impact on import accuracy but may affect performance when run with a large
   number (100+) of loaded buffers.
 
 - Import on completion
@@ -268,7 +270,12 @@ nvim_lsp.tsserver.setup {
 
             -- import all
             import_all_timeout = 5000, -- ms
-            import_all_disable_priority = false,
+            import_all_priorities = {
+                buffers = 4, -- loaded buffer names
+                buffer_content = 3, -- loaded buffer content
+                local_files = 2, -- git files or files with relative path markers
+                same_file = 1, -- add to existing import statement
+            },
             import_all_scan_buffers = 100,
 
             -- eslint
@@ -297,10 +304,11 @@ nvim_lsp.tsserver.setup {
         ts_utils.setup_client(client)
 
         -- no default maps, so you may want to define some here
-        vim.api.nvim_buf_set_keymap(bufnr, "n", "gs", ":TSLspOrganize<CR>", {silent = true})
-        vim.api.nvim_buf_set_keymap(bufnr, "n", "qq", ":TSLspFixCurrent<CR>", {silent = true})
-        vim.api.nvim_buf_set_keymap(bufnr, "n", "gr", ":TSLspRenameFile<CR>", {silent = true})
-        vim.api.nvim_buf_set_keymap(bufnr, "n", "gi", ":TSLspImportAll<CR>", {silent = true})
+        local opts = {silent = true}
+        vim.api.nvim_buf_set_keymap(bufnr, "n", "gs", ":TSLspOrganize<CR>", opts)
+        vim.api.nvim_buf_set_keymap(bufnr, "n", "qq", ":TSLspFixCurrent<CR>", opts)
+        vim.api.nvim_buf_set_keymap(bufnr, "n", "gr", ":TSLspRenameFile<CR>", opts)
+        vim.api.nvim_buf_set_keymap(bufnr, "n", "gi", ":TSLspImportAll<CR>", opts)
     end
 }
 ```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ possibility. If something doesn't work, please let me know!
   you frequently see timeout warnings, you can change `import_all_timeout` (see
   below).
 
+  By default, the command will resolve conflicting imports by checking other
+  imports in the same file and other open buffers. This has a minor performance
+  impact, but you can disable the feature entirely by setting
+  `import_all_disable_priority` to `true` (see below).
+
+  `:TSLspImportAll` can also scan the content of other open buffers to resolve
+  import priority, limited by `import_all_scan_buffers` (set to `0` by default).
+  This has a positive impact on import accuracy but a larger performance impact.
+
 - Import on completion
 
   Adds missing imports on completion confirm (`<C-y>`) when using the built-in
@@ -254,7 +263,11 @@ nvim_lsp.tsserver.setup {
             debug = false,
             disable_commands = false,
             enable_import_on_completion = false,
+
+            -- import all
             import_all_timeout = 5000, -- ms
+            import_all_disable_priority = false,
+            import_all_scan_buffers = 0
 
             -- eslint
             eslint_enable_code_actions = true,

--- a/lua/nvim-lsp-ts-utils/import-all.lua
+++ b/lua/nvim-lsp-ts-utils/import-all.lua
@@ -215,7 +215,7 @@ return a.async_void(function(bufnr)
     local last_request_time = vim.loop.now()
     local wait_for_request = function()
         vim.wait(250, function()
-            return vim.loop.now() - last_request_time > 25
+            return vim.loop.now() - last_request_time > 10
         end, 5)
         last_request_time = vim.loop.now()
     end

--- a/lua/nvim-lsp-ts-utils/options.lua
+++ b/lua/nvim-lsp-ts-utils/options.lua
@@ -18,7 +18,7 @@ local defaults = {
     -- import all
     import_all_timeout = 5000,
     import_all_disable_priority = false,
-    import_all_scan_buffers = 0,
+    import_all_scan_buffers = 100,
     -- completion
     enable_import_on_completion = false,
     complete_parens = false,

--- a/lua/nvim-lsp-ts-utils/options.lua
+++ b/lua/nvim-lsp-ts-utils/options.lua
@@ -23,6 +23,7 @@ local defaults = {
         local_files = 2,
         same_file = 1,
     },
+    import_all_select_source = false,
     import_all_scan_buffers = 100,
     -- completion
     enable_import_on_completion = false,

--- a/lua/nvim-lsp-ts-utils/options.lua
+++ b/lua/nvim-lsp-ts-utils/options.lua
@@ -17,6 +17,8 @@ local defaults = {
     disable_commands = false,
     -- import all
     import_all_timeout = 5000,
+    import_all_disable_priority = false,
+    import_all_scan_buffers = 0,
     -- completion
     enable_import_on_completion = false,
     complete_parens = false,

--- a/lua/nvim-lsp-ts-utils/options.lua
+++ b/lua/nvim-lsp-ts-utils/options.lua
@@ -17,7 +17,12 @@ local defaults = {
     disable_commands = false,
     -- import all
     import_all_timeout = 5000,
-    import_all_disable_priority = false,
+    import_all_priorities = {
+        buffers = 4,
+        buffer_content = 3,
+        local_files = 2,
+        same_file = 1,
+    },
     import_all_scan_buffers = 100,
     -- completion
     enable_import_on_completion = false,

--- a/lua/nvim-lsp-ts-utils/organize-imports.lua
+++ b/lua/nvim-lsp-ts-utils/organize-imports.lua
@@ -3,29 +3,32 @@ local u = require("nvim-lsp-ts-utils.utils")
 local lsp = vim.lsp
 local api = vim.api
 
+local METHOD = "workspace/executeCommand"
+
 local M = {}
-local get_organize_params = function(bufnr)
+local make_params = function(bufnr)
     return {
         command = "_typescript.organizeImports",
         arguments = { u.buffer.name(bufnr) },
     }
 end
 
-local organize_imports = function(bufnr)
-    if not bufnr then
-        bufnr = api.nvim_get_current_buf()
-    end
+local organize_imports = function(bufnr, post)
+    bufnr = bufnr or api.nvim_get_current_buf()
 
-    lsp.buf.execute_command(get_organize_params(bufnr))
+    lsp.buf_request(bufnr, METHOD, make_params(bufnr), function(err)
+        if not err and post then
+            post()
+        end
+    end)
 end
 M.async = organize_imports
 
 local organize_imports_sync = function(bufnr)
-    if not bufnr then
-        bufnr = api.nvim_get_current_buf()
-    end
+    bufnr = bufnr or api.nvim_get_current_buf()
 
-    lsp.buf_request_sync(bufnr, "workspace/executeCommand", get_organize_params(bufnr), 500)
+    lsp.buf_request_sync(bufnr, METHOD, make_params(bufnr), 500)
 end
 M.sync = organize_imports_sync
+
 return M

--- a/lua/nvim-lsp-ts-utils/utils.lua
+++ b/lua/nvim-lsp-ts-utils/utils.lua
@@ -210,18 +210,21 @@ M.buffer = {
 }
 
 M.get_command_output = function(cmd, args)
-    local stderr = {}
-    local stdout, ret = Job
+    local error
+    local output, ret = Job
         :new({
             command = cmd,
             args = args,
             cwd = M.buffer.root(),
             on_stderr = function(_, data)
-                table.insert(stderr, data)
+                M.debug_log(string.format("error running command %s: %s", cmd, data))
+                error = true
             end,
         })
         :sync()
-    return stdout, ret, stderr
+    M.debug_log(string.format("command %s exited with code %d", cmd, ret))
+    error = error or ret ~= 0
+    return error and {} or output
 end
 
 return M

--- a/lua/nvim-lsp-ts-utils/utils.lua
+++ b/lua/nvim-lsp-ts-utils/utils.lua
@@ -1,4 +1,5 @@
 local scan_dir = require("plenary.scandir").scan_dir
+local Job = require("plenary.job")
 local lspconfig = require("lspconfig/util")
 
 local o = require("nvim-lsp-ts-utils.options")
@@ -207,5 +208,20 @@ M.buffer = {
         )(fname) or _G._TEST and vim.fn.getcwd()
     end,
 }
+
+M.get_command_output = function(cmd, args)
+    local stderr = {}
+    local stdout, ret = Job
+        :new({
+            command = cmd,
+            args = args,
+            cwd = M.buffer.root(),
+            on_stderr = function(_, data)
+                table.insert(stderr, data)
+            end,
+        })
+        :sync()
+    return stdout, ret, stderr
+end
 
 return M

--- a/test/spec/e2e_spec.lua
+++ b/test/spec/e2e_spec.lua
@@ -103,20 +103,13 @@ describe("e2e", function()
                 -- jump to line containing error
                 vim.cmd("2")
             end)
+
             it("should apply eslint fix", function()
                 ts_utils.fix_current()
                 lsp_wait()
 
                 -- check that eslint fix has been applied, replacing == with ===
                 assert.equals(get_buf_content(2), [[  if (typeof user.name === "string") {]])
-            end)
-
-            it("should add disable rule comment with matching indentation", function()
-                -- specify index to choose disable action
-                ts_utils.fix_current(2)
-                lsp_wait()
-
-                assert.equals(get_buf_content(2), "  // eslint-disable-next-line eqeqeq")
             end)
         end)
     end)


### PR DESCRIPTION
Closes #42. 

This implementation prioritizes imports in the following (descending) order:

1. Imports from a source already used in the current file, identified by `Add`.
2. Imports from local sources (imperfect, a bit more on this below).
3. Imports from open buffers. It'll check buffer names to see if they match the source and also scan buffer content to see if a matching import statement exists.
4. Imports from non-local sources.

There's a small performance tradeoff from the priority check, especially with big imports, but I think it's acceptable given the advantages, so I've enabled the feature by default but added the option `import_all_disable_priority` to force the old (VS Code-compliant) behavior. 

For 2 in the list above, there's no definite marker to distinguish between local and non-local imports. Relative paths that start with `./` are a good indicator, but `tsconfig.json` has a `baseUrl` option that messes with this. Ultimately, I think we can't predict this perfectly, but we can add more patterns and improve accuracy (I've started with `src` for now). 

For 3, I added the option `import_all_scan_buffers` (number) to limit the number of buffers that will be scanned. On my end, scanning buffers is surprisingly fast, but I've defaulted the option to `0` to prevent issues with other workflows / bigger projects.