### PR TITLE
[Feature]: Add issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug Report
+title: "[BUG] <title>"
+description: Report a problem in nvim-lsp-ts-utils
+labels: [bug]
+body:
+
+  - type: checkboxes
+    id: faq-prerequisite
+    attributes:
+      label: FAQ
+      options:
+        - label: I have checked [troubleshooting](https://github.com/jose-elias-alvarez/nvim-lsp-ts-utils#troubleshooting) and it didn't resolve my problem.
+          required: true
+
+  - type: checkboxes
+    id: issue-prerequisite
+    attributes:
+      label: Issues
+      options:
+        - label: I have checked [existing issues](https://github.com/jose-elias-alvarez/nvim-lsp-ts-utils/issues?q=is%3Aissue+) and there are no issues with the same problem.
+          required: true
+
+  - type: input
+    attributes:
+      label: "Neovim Version"
+      description: "`nvim --version`:"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: "Steps to reproduce"
+
+  - type: textarea
+    attributes:
+      label: "Expected behavior"
+
+  - type: textarea
+    attributes:
+      label: "Actual behavior"
+      description: "A description of the behavior you expected. May optionally include logs, images, or videos."
+
+  - type: dropdown
+    id: help
+    attributes:
+      label: "Help"
+      description: "Would you be able to resolve this issue by submitting a pull request?"
+      options:
+        - "Yes"
+        - "Yes, but I don't know how to start. I would need guidance"
+        - "No"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: "Implementation help"
+      description: "If you selected yes in the last question please specify in detail what you would need help with in order to implement this."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-title: "[BUG] <title>"
+title: "[BUG] "
 description: Report a problem in nvim-lsp-ts-utils
 labels: [bug]
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+title: "[FEATURE REQUEST] "
+description: Request an enhancement for nvim-lsp-ts-utils
+labels: [enhancement]
+body:
+
+  - type: checkboxes
+    id: issue-prerequisite
+    attributes:
+      label: Issues
+      options:
+        - label: I have checked [existing issues](https://github.com/jose-elias-alvarez/nvim-lsp-ts-utils/issues) and there are no existing ones with the same request.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: "Feature description"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: help
+    attributes:
+      label: "Help"
+      description: "Would you be able to resolve this issue by submitting a pull request?"
+      options:
+        - "Yes"
+        - "Yes, but I don't know how to start. I would need guidance"
+        - "No"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: "Implementation help"
+      description: "If you selected yes in the last question please specify in detail what you would need help with in order to implement this."
+    validations:
+      required: false


### PR DESCRIPTION
Adding forms here as promised in [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim/pull/61).

I added a default title prefix here since people often add their own to try and categorize issues. This often leads to a lot of different conventions of issue titles. If you think it's a good idea ill add it to the `null-ls` repo as well.

Adding a default title prefix should fix that.