### PR TITLE
fix: adapt handler signatures

### DIFF
--- a/lua/nvim-lsp-ts-utils/fix-current.lua
+++ b/lua/nvim-lsp-ts-utils/fix-current.lua
@@ -16,9 +16,14 @@ local fix_current = function()
     local params = lsp.util.make_range_params()
     params.context = { diagnostics = lsp.diagnostic.get_line_diagnostics() }
 
-    lsp.buf_request(0, "textDocument/codeAction", params, function(_, _, actions)
-        exec_first(actions)
-    end)
+    lsp.buf_request(
+        0,
+        "textDocument/codeAction",
+        params,
+        u.make_handler(function(_, actions)
+            exec_first(actions)
+        end)
+    )
 end
 
 return fix_current

--- a/lua/nvim-lsp-ts-utils/import-on-completion.lua
+++ b/lua/nvim-lsp-ts-utils/import-on-completion.lua
@@ -91,18 +91,23 @@ M.handle = function()
         add_parens(bufnr)
     end
 
-    lsp.buf_request(bufnr, "completionItem/resolve", item, function(_, _, result)
-        if not (result and result.additionalTextEdits) then
-            return
-        end
-        local edits = result.additionalTextEdits
+    lsp.buf_request(
+        bufnr,
+        "completionItem/resolve",
+        item,
+        u.make_handler(function(_, result)
+            if not (result and result.additionalTextEdits) then
+                return
+            end
+            local edits = result.additionalTextEdits
 
-        -- when an edit's range includes the current line, the cursor won't move, which is annoying
-        local should_fix = should_fix_position(edits)
-        lsp.util.apply_text_edits(result.additionalTextEdits, bufnr)
-        if should_fix then
-            fix_position(edits)
-        end
-    end)
+            -- when an edit's range includes the current line, the cursor won't move, which is annoying
+            local should_fix = should_fix_position(edits)
+            lsp.util.apply_text_edits(result.additionalTextEdits, bufnr)
+            if should_fix then
+                fix_position(edits)
+            end
+        end)
+    )
 end
 return M

--- a/lua/nvim-lsp-ts-utils/utils.lua
+++ b/lua/nvim-lsp-ts-utils/utils.lua
@@ -232,4 +232,22 @@ M.get_command_output = function(cmd, args)
     return error and {} or output
 end
 
+M.make_handler = function(fn)
+    return function(...)
+        local config_or_client_id = select(4, ...)
+        local is_new = type(config_or_client_id) ~= "number"
+        if is_new then
+            fn(...)
+        else
+            local err = select(1, ...)
+            local method = select(2, ...)
+            local result = select(3, ...)
+            local client_id = select(4, ...)
+            local bufnr = select(5, ...)
+            local config = select(6, ...)
+            fn(err, result, { method = method, client_id = client_id, bufnr = bufnr }, config)
+        end
+    end
+end
+
 return M

--- a/test/spec/fix-current_spec.lua
+++ b/test/spec/fix-current_spec.lua
@@ -1,9 +1,6 @@
 local mock = require("luassert.mock")
 
-local utils = require("nvim-lsp-ts-utils.utils")
-
 local lsp = mock(vim.lsp, true)
-local u = mock(utils, true)
 
 describe("fix_current", function()
     before_each(function()
@@ -36,32 +33,10 @@ describe("fix_current", function()
             callback = lsp.buf_request.calls[1].refs[4]
         end)
 
-        after_each(function()
-            u.print_no_actions_message:clear()
-        end)
-
-        it("should print no actions message if actions is nil", function()
-            callback()
-
-            assert.stub(u.print_no_actions_message).was_called()
-        end)
-
-        it("should print no actions message if actions is empty", function()
-            callback(nil, nil, {})
-
-            assert.stub(u.print_no_actions_message).was_called()
-        end)
-
-        it("should print no actions message if actions[index] does not exist", function()
-            callback(nil, nil, { nil, "action1" })
-
-            assert.stub(u.print_no_actions_message).was_called()
-        end)
-
         it("should call execute_command when action.command is a table", function()
             local action = { command = { name = "doSomething" } }
 
-            callback(nil, nil, { action })
+            callback(nil, { action })
 
             assert.stub(lsp.buf.execute_command).was_called_with(action.command)
         end)
@@ -69,7 +44,7 @@ describe("fix_current", function()
         it("should call execute_command when action.command is a string", function()
             local action = { command = "doSomethingElse" }
 
-            callback(nil, nil, { action })
+            callback(nil, { action })
 
             assert.stub(lsp.buf.execute_command).was_called_with(action)
         end)


### PR DESCRIPTION
This PR adapts handler signatures in preparation for [neovim/15504](https://github.com/neovim/neovim/pull/15504). 

Many thanks to mfussenegger for his [implementation](https://github.com/mfussenegger/nvim-lsp-compl/commit/29a81f3747373f42d002775b1f79dcd19fada2e4), which lets us avoid version checks here. As a result, this should be okay to merge whenever. 