### PR TITLE
Support 'typescript' as LSP client name

### DIFF
--- a/lua/nvim-lsp-ts-utils/rename-file.lua
+++ b/lua/nvim-lsp-ts-utils/rename-file.lua
@@ -8,7 +8,7 @@ local fn = vim.fn
 local rename_file = function(source, target)
     local client_found, request_ok
     for _, client in ipairs(lsp.get_active_clients()) do
-        if not client_found and client.name == "tsserver" then
+        if not client_found and (client.name == "tsserver" or client.name == 'typescript') then
             client_found = true
             request_ok = client.request("workspace/executeCommand", {
                 command = "_typescript.applyRenameFile",

--- a/lua/nvim-lsp-ts-utils/rename-file.lua
+++ b/lua/nvim-lsp-ts-utils/rename-file.lua
@@ -8,7 +8,7 @@ local fn = vim.fn
 local rename_file = function(source, target)
     local client_found, request_ok
     for _, client in ipairs(lsp.get_active_clients()) do
-        if not client_found and (client.name == "tsserver" or client.name == 'typescript') then
+        if not client_found and (client.name == "tsserver" or client.name == "typescript") then
             client_found = true
             request_ok = client.request("workspace/executeCommand", {
                 command = "_typescript.applyRenameFile",


### PR DESCRIPTION
[nvim-lspinstall](https://github.com/kabouzeid/nvim-lspinstall) uses a different naming scheme than lspconfig -- the Typescript client is 'typescript' rather than 'tsserver'. This PR updates the rename-file functionality, which seems to be the only place that explicitly looks for the server, to consider 'typescript' as well as 'tsserver'.