### PR TITLE
refactor: incremental update of inlay hints and more options

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,14 @@ built-in LSP client.
   - `inlay_hints_highlight` (string): Highlight group used for inlay hints.
     Defaults to "Comment".
 
-- Filter `tsserver` diagnostics
+  - `inlay_hints_priority` (number): Priority of the hint extmarks. Change
+    this value if the inlay hints conflict with other extmarks. Defaults to
+    200.
+
+  - `inlay_hints_format` (table): Format options for individual kind of inlay
+    hints. See [Setup](#setup) section for default settings and example.
+
+-  Filter `tsserver` diagnostics
 
   Some `tsserver` diagnostics may be annoying or can result in duplicated
   messages when used with a linter. For example, to disable the hint about
@@ -171,16 +178,17 @@ lspconfig.tsserver.setup({
             auto_inlay_hints = true,
             inlay_hints_highlight = "Comment",
             inlay_hints_priority = 200, -- priority of the hint extmarks
-            inlay_hints_throttle = vim.o.updatetime, -- throttle the inlay hint request, set to 0 for no throttle
             inlay_hints_format = { -- format options for individual hint kind
-                Type = {
-                    highlight = nil,
-                    text = function(text)
-                        return "->" .. text:sub(2)
-                    end,
-                },
+                Type = {},
                 Parameter = {},
                 Enum = {},
+                -- Example format customization for `Type` kind:
+                -- Type = {
+                --     highlight = "Comment",
+                --     text = function(text)
+                --         return "->" .. text:sub(2)
+                --     end,
+                -- },
             },
 
             -- update imports on file move

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ built-in LSP client.
     this value if the inlay hints conflict with other extmarks. Defaults to
     200.
 
+  - `inlay_hints_throttle` (number): Throttle time of inlay hints requests in ms.
+    Defaults to 150.
+
   - `inlay_hints_format` (table): Format options for individual kind of inlay
     hints. See [Setup](#setup) section for default settings and example.
 
@@ -178,6 +181,7 @@ lspconfig.tsserver.setup({
             auto_inlay_hints = true,
             inlay_hints_highlight = "Comment",
             inlay_hints_priority = 200, -- priority of the hint extmarks
+            inlay_hints_throttle = 150, -- throttle the inlay hint request
             inlay_hints_format = { -- format options for individual hint kind
                 Type = {},
                 Parameter = {},

--- a/README.md
+++ b/README.md
@@ -170,6 +170,18 @@ lspconfig.tsserver.setup({
             -- inlay hints
             auto_inlay_hints = true,
             inlay_hints_highlight = "Comment",
+            inlay_hints_priority = 200, -- priority of the hint extmarks
+            inlay_hints_throttle = vim.o.updatetime, -- throttle the inlay hint request, set to 0 for no throttle
+            inlay_hints_format = { -- format options for individual hint kind
+                Type = {
+                    highlight = nil,
+                    text = function(text)
+                        return "->" .. text:sub(2)
+                    end,
+                },
+                Parameter = {},
+                Enum = {},
+            },
 
             -- update imports on file move
             update_imports_on_move = false,

--- a/lua/nvim-lsp-ts-utils/init.lua
+++ b/lua/nvim-lsp-ts-utils/init.lua
@@ -51,7 +51,6 @@ M.setup = function(user_options)
     define_commands()
 
     if o.get().auto_inlay_hints then
-        inlay_hints.setup_autocommands()
         inlay_hints.inlay_hints()
     end
 

--- a/lua/nvim-lsp-ts-utils/inlay-hints.lua
+++ b/lua/nvim-lsp-ts-utils/inlay-hints.lua
@@ -30,7 +30,7 @@ local function set_buf_enabled(bufnr)
 end
 
 local function set_buf_disabled(bufnr)
-    M.enabled[resolve_bufnr(bufnr)] = false
+    M.enabled[resolve_bufnr(bufnr)] = nil
 end
 
 -- end_line is inclusive

--- a/lua/nvim-lsp-ts-utils/inlay-hints.lua
+++ b/lua/nvim-lsp-ts-utils/inlay-hints.lua
@@ -109,14 +109,12 @@ function M.inlay_hints(bufnr)
     local params = { textDocument = vim.lsp.util.make_text_document_params() }
     vim.lsp.buf_request(bufnr, INLAY_HINTS_METHOD, params, handler)
 
-    local throttle = o.get().inlay_hints_throttle
+    local throttle = vim.o.updatetime
     local function inlay_hints_request(start, new_end)
         params = vim.lsp.util.make_given_range_params({ start + 1, 0 }, { new_end + 1, 0 })
         vim.lsp.buf_request(bufnr, INLAY_HINTS_METHOD, params, handler)
     end
-    if throttle > 0 then
-        inlay_hints_request = u.throttle_fn(throttle, vim.schedule_wrap(inlay_hints_request))
-    end
+    inlay_hints_request = u.throttle_fn(throttle, vim.schedule_wrap(inlay_hints_request))
 
     local attached = api.nvim_buf_attach(bufnr, false, {
         on_lines = function(_, _, _, start, old_end, new_end)

--- a/lua/nvim-lsp-ts-utils/inlay-hints.lua
+++ b/lua/nvim-lsp-ts-utils/inlay-hints.lua
@@ -132,7 +132,7 @@ function M.inlay_hints(bufnr)
     local params = { textDocument = vim.lsp.util.make_text_document_params() }
     vim.lsp.buf_request(bufnr, INLAY_HINTS_METHOD, params, make_handler({ event = { start_line = 0, end_line = -1 } }))
 
-    local throttle = vim.o.updatetime
+    local throttle = o.get().inlay_hints_throttle
     local function inlay_hints_request(ctx)
         if ctx.event then
             params = vim.lsp.util.make_given_range_params(

--- a/lua/nvim-lsp-ts-utils/options.lua
+++ b/lua/nvim-lsp-ts-utils/options.lua
@@ -29,14 +29,8 @@ local defaults = {
     auto_inlay_hints = true,
     inlay_hints_highlight = "Comment",
     inlay_hints_priority = 200,
-    inlay_hints_throttle = vim.o.updatetime,
     inlay_hints_format = {
-        Type = {
-            highlight = nil,
-            text = function(text)
-                return "->" .. text:sub(2)
-            end,
-        },
+        Type = { highlight = nil, text = nil },
         Parameter = { highlight = nil, text = nil },
         Enum = { highlight = nil, text = nil },
     },

--- a/lua/nvim-lsp-ts-utils/options.lua
+++ b/lua/nvim-lsp-ts-utils/options.lua
@@ -28,6 +28,7 @@ local defaults = {
     -- inlay hints
     auto_inlay_hints = true,
     inlay_hints_highlight = "Comment",
+    inlay_hints_throttle = 150,
     inlay_hints_priority = 200,
     inlay_hints_format = {
         Type = { highlight = nil, text = nil },

--- a/lua/nvim-lsp-ts-utils/options.lua
+++ b/lua/nvim-lsp-ts-utils/options.lua
@@ -28,6 +28,18 @@ local defaults = {
     -- inlay hints
     auto_inlay_hints = true,
     inlay_hints_highlight = "Comment",
+    inlay_hints_priority = 200,
+    inlay_hints_throttle = vim.o.updatetime,
+    inlay_hints_format = {
+        Type = {
+            highlight = nil,
+            text = function(text)
+                return "->" .. text:sub(2)
+            end,
+        },
+        Parameter = { highlight = nil, text = nil },
+        Enum = { highlight = nil, text = nil },
+    },
 
     -- internal
     _initialized = false,

--- a/lua/nvim-lsp-ts-utils/utils.lua
+++ b/lua/nvim-lsp-ts-utils/utils.lua
@@ -164,4 +164,22 @@ M.buf_autocmd = function(name, event, func)
     )
 end
 
+M.throttle_fn = function(ms, fn)
+    local last_time = 0
+    local timer = vim.loop.new_timer()
+    return function(...)
+        local now = vim.loop.now()
+        local args = {...}
+        if now - last_time > ms then
+            last_time = now
+            fn(unpack(args))
+        end
+        timer:stop()
+        timer:start(ms - now + last_time, 0, function()
+            last_time = vim.loop.now()
+            fn(unpack(args))
+        end)
+    end
+end
+
 return M

--- a/lua/nvim-lsp-ts-utils/utils.lua
+++ b/lua/nvim-lsp-ts-utils/utils.lua
@@ -169,7 +169,7 @@ M.throttle_fn = function(ms, fn)
     local timer = vim.loop.new_timer()
     return function(...)
         local now = vim.loop.now()
-        local args = {...}
+        local args = { ... }
         if now - last_time > ms then
             last_time = now
             fn(unpack(args))


### PR DESCRIPTION
Previously, the inlay hints are dropped and requested as a whole on every update of text. This will cause apparent lag in large file, and tsserver is even less responsive as it's busy dealing with the large amounts of inlay hints. By requesting and updating the hints incrementally, the performance will be much better.

Three extra options are exposed to help customization. 
- `inlay_hints_priority` is used to resolve the conflict with other extmarks set on the same line. 
- `inlay_hints_throttle` configures the throttle time of requests as the text may change much frequently.
- `inlay_hints_format` allow user to customize the highlight and text of different kind of hints, because the original text format of hint is confusing when messed up on the single line (`param: ` and `: return`). 