### PR TITLE
POF: Do not reorder imports if not necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ lspconfig.tsserver.setup({
             },
             import_all_scan_buffers = 100,
             import_all_select_source = false,
-            -- if false will avoid orginizing imports
+            -- if false will avoid organizing imports
             always_organize_imports = true,
 
             -- filter diagnostics

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ built-in LSP client.
   LSP `omnifunc`. Enable by setting `enable_import_on_completion` to `true`
   inside `setup` (see below).
 
+- Avoid organizing imports
+
+  By default `always_organize_imports` is set to `true`, every call to
+  `:TSLspImportAll` or `:TSLspImportCurrent` will also run `:TSLspOrganize`
+  to fix possible duplicated imports.
+
+  If `always_organize_imports` is set to `false`, it will only run
+  `:TSLspOrganize` in situations where is necessary: i.e. two new imports
+  from the same module.
+
+
 - Fix invalid ranges
 
   `tsserver` uses non-compliant ranges in some code actions (most notably "Move
@@ -162,6 +173,8 @@ lspconfig.tsserver.setup({
             },
             import_all_scan_buffers = 100,
             import_all_select_source = false,
+            -- if false will avoid orginizing imports
+            always_organize_imports = true,
 
             -- filter diagnostics
             filter_out_diagnostics_by_severity = {},

--- a/lua/nvim-lsp-ts-utils/import-all.lua
+++ b/lua/nvim-lsp-ts-utils/import-all.lua
@@ -187,12 +187,12 @@ local should_reorder = function(edits)
                 return
             end
 
-            local import = module:gsub("\n", "")
-            if modules[import] then
+            local source = vim.trim(module)
+            if modules[source] then
                 return true
             end
 
-            modules[import] = true
+            modules[source] = true
         end
     end
     return false

--- a/lua/nvim-lsp-ts-utils/options.lua
+++ b/lua/nvim-lsp-ts-utils/options.lua
@@ -12,6 +12,7 @@ local defaults = {
     },
     import_all_select_source = false,
     import_all_scan_buffers = 100,
+    always_organize_imports = true,
 
     -- completion
     enable_import_on_completion = false,


### PR DESCRIPTION
Based on our discussion here https://github.com/jose-elias-alvarez/nvim-lsp-ts-utils/discussions/90

TL;DR: Call sort imports only if more than 1 import from the same module was added.

Background
==

The current import all `import_all` and import current `import_current` algorithms will perform an organize import action after the edits are applied.

This behaviour exists to prevent situations where TS code actions require to import two dependencies from the same module. But this is not always the case for all situations.

Re-organizing imports on import can become problematic for code bases that don't have a standard for imports order, or that have one that doesn't match the default TS one. 

Re-organizing imports on import all or current also creates more changes on the file that required, e.g. when a single line of code with a function call is added and after using import current or import all, the file gets much more changes related only to the imports order.

What the plugin does to auto-import all is loop through ts code-actions and apply them.

The change:
=====

What my change does is keep track of how many imports of the same module had been applied, and if more than 1 was applied it would then perform an import sort[1]

[1] I checked the TS server and I can't find a way to only de-duplicate the imports, the sort and import are always together. It would be idea to have a TS action only to de-dupe the imports.

Extended background
==

There are widely two cases I considered for this PR:

1. TS suggests to import two modules from the same file that will result on incorrect duplicate imports

```typescript
// file test.ts
export function test1();
export function test2();

// file imports.ts
import example from 'example';

example();
test1(); // test1 is not defined
test2(); // test2 is not defined
```

In this case, ts will suggest two actions: 
* import test1 from './test';
* import test2 from './test';

Applying auto import (both code actions) will result in the following incorrect code:

```typescript
// file imports.ts
import example from 'example';
import {test1} from './test';
import {test2} from './test'; //duplicated import

example();
test1(); 
test2(); 
```

2. TS suggests to import (or add) an import 

```typescript
// file imports.ts
import example from 'example';
import {test1} from './test';

example();
test1();
test2();  // test2 is not defined
```

Applying auto import (one code action). will result in the following correct code

```typescript
// file imports.ts
import example from 'example';
import {test1, test2} from './test';

example();
test1(); 
test2();
```

Videos
==

Add to existing import (no sorting):
![Peek 2021-12-31 13-13](https://user-images.githubusercontent.com/227916/147822792-0fca3ded-69cf-4f63-a03b-4b88cf1ea9e4.gif)

Import module (no sorting):
![Peek 2021-12-31 13-14](https://user-images.githubusercontent.com/227916/147822841-7d438e71-593a-4bba-8339-ca30014677b5.gif)

import two from the same module (sorting):
![Peek 2021-12-31 13-15](https://user-images.githubusercontent.com/227916/147822865-a26f7119-d5d0-4213-bf2a-38cd33d15907.gif)

Add two to existing import (no sorting)
![Peek 2021-12-31 13-16](https://user-images.githubusercontent.com/227916/147822900-04af2483-db03-4d06-96d2-dc9da98b8bf1.gif)


