### PR TITLE
feat(organize imports): configurable timeout, and return status

### DIFF
--- a/lua/nvim-lsp-ts-utils/organize-imports.lua
+++ b/lua/nvim-lsp-ts-utils/organize-imports.lua
@@ -22,10 +22,10 @@ local organize_imports = function(bufnr, post)
 end
 M.async = organize_imports
 
-local organize_imports_sync = function(bufnr)
+local organize_imports_sync = function(bufnr, timeout)
     bufnr = bufnr or api.nvim_get_current_buf()
 
-    lsp.buf_request_sync(bufnr, METHOD, make_params(bufnr), 500)
+    return lsp.buf_request_sync(bufnr, METHOD, make_params(bufnr), timeout)
 end
 M.sync = organize_imports_sync
 


### PR DESCRIPTION
Use the default timeout of 1000 for buf_request_sync(), but allow caller
to override.

Return the result or status/err pair so that the caller can handle.

I am now using this in my own formatting function:

```lua
function my.format_code()
  local bufnr = vim.api.nvim_get_current_buf()
  local tsserver_is_attached = false
  for _, client in ipairs(vim.lsp.buf_get_clients(bufnr)) do
    if client.name == "tsserver" then
      tsserver_is_attached = true
      break
    end
  end
  if tsserver_is_attached then
    local status, err = require('nvim-lsp-ts-utils').organize_imports_sync(bufnr)
    if not status then
      my.error("organize_imports_sync failed with: " .. err)
    end
  end
  vim.lsp.buf.formatting_seq_sync(nil, 5000)
end
```

See https://github.com/jose-elias-alvarez/nvim-lsp-ts-utils/discussions/109