### PR TITLE
feat: support source actions

### DIFF
--- a/lua/nvim-lsp-ts-utils/source-actions.lua
+++ b/lua/nvim-lsp-ts-utils/source-actions.lua
@@ -1,0 +1,50 @@
+local u = require("nvim-lsp-ts-utils.utils")
+
+local lsp = vim.lsp
+
+local method = "textDocument/codeAction"
+
+local source_actions = {
+    SourceAddMissingImportsTs = "source.addMissingImports.ts",
+    SourceFixAllTs = "source.fixAll.ts",
+    SourceRemoveUnusedTs = "source.removeUnused.ts",
+    SourceOrganizeImportsTs = "source.organizeImports.ts",
+}
+
+local make_source_action_command = function(source_action)
+    return function(bufnr)
+        local client = u.get_tsserver_client()
+        if not client then
+            return
+        end
+
+        bufnr = bufnr or vim.api.nvim_get_current_buf()
+        local context = {
+            only = { source_action },
+            diagnostics = vim.diagnostic.get(bufnr),
+        }
+        local params = lsp.util.make_range_params()
+        params.context = context
+
+        client.request(method, params, function(err, res)
+            assert(not err, err)
+            if
+                res
+                and res[1]
+                and res[1].edit
+                and res[1].edit.documentChanges
+                and res[1].edit.documentChanges[1]
+                and res[1].edit.documentChanges[1].edits
+            then
+                lsp.util.apply_text_edits(res[1].edit.documentChanges[1].edits, bufnr, client.offset_encoding)
+            end
+        end, bufnr)
+    end
+end
+
+return {
+    add_missing_imports = make_source_action_command(source_actions.SourceAddMissingImportsTs),
+    fix_all = make_source_action_command(source_actions.SourceFixAllTs),
+    remove_unused = make_source_action_command(source_actions.SourceRemoveUnusedTs),
+    organize_imports = make_source_action_command(source_actions.SourceOrganizeImportsTs),
+}


### PR DESCRIPTION
Will close #100.

I dug through the `typescript-language-server` code and figured out how to get these to work in Neovim. This is just a preliminary POC. since I want to implement a few more things (commands, sync actions) before merging.

It should be safe to replace the existing `organizeImports` command with this one, and `removeUnused` and `fixAll` are nice additions. The question is what to do with `addMissingImports`. Our implementation has some nice improvements like priority, but it's quite brittle compared to simply requesting and applying results from a language server. The new one should emulate VS Code behavior, which I think is good enough.

Generally, removing bespoke functionality and shifting it over to the server is a good idea. This may pave the way for a version 2 of this plugin that focuses on easily setting up `typescript-language-server` and adding commands for convenience.